### PR TITLE
Update builder command

### DIFF
--- a/builders/alpine/README.md
+++ b/builders/alpine/README.md
@@ -5,7 +5,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:alpine --config builder.toml
+pack builder create cnbs/sample-builder:alpine --config builder.toml
 ```
 
 #### Build app with builder


### PR DESCRIPTION
Update builder command after receiving this message using CLI (0.17.0): "Warning: Command pack create-builder has been deprecated, please use pack builder create instead"